### PR TITLE
TextSplitter: 前置詞の前で文章を区切るように修正した #67

### DIFF
--- a/functions/src/TextSplitter.ts
+++ b/functions/src/TextSplitter.ts
@@ -1,8 +1,17 @@
 const Tokenizer = require("sentence-tokenizer");
 
-const PUNCTUATIONS = [","];
-const INTERROGATIVES = ["what", "who", "where", "when", "why", "how", "whose"];
-const CONJUNCTIONS = [
+const MIN_WORDS_LENGTH = 3;
+const PUNCTUATIONS: string[] = [","];
+const INTERROGATIVES: string[] = [
+  "what",
+  "who",
+  "where",
+  "when",
+  "why",
+  "how",
+  "whose"
+];
+const CONJUNCTIONS: string[] = [
   "and",
   "after",
   "also",
@@ -17,6 +26,28 @@ const CONJUNCTIONS = [
   "unless",
   "until"
 ];
+const PREPOSITIONS: string[] = [
+  "about",
+  "as",
+  "at",
+  "between",
+  "during",
+  "for",
+  "from",
+  "in",
+  "on",
+  "over",
+  "regarding",
+  "since",
+  "till",
+  "to",
+  "under",
+  "unless",
+  "until",
+  "with",
+  "within",
+  "without"
+];
 
 export default class TextSplitter {
   static run(text: string): string[] {
@@ -24,6 +55,7 @@ export default class TextSplitter {
     sentences = this.splitSentencesWithPunctuations(sentences, PUNCTUATIONS);
     sentences = this.splitSentencesWithDelimiters(sentences, INTERROGATIVES);
     sentences = this.splitSentencesWithDelimiters(sentences, CONJUNCTIONS);
+    sentences = this.splitSentencesWithDelimiters(sentences, PREPOSITIONS);
 
     return sentences;
   }
@@ -81,10 +113,10 @@ export default class TextSplitter {
       }
 
       if (
-        this.isShortEnough(currentText, 3) ||
-        this.isShortEnough(text, 3) ||
+        this.isShortEnough(currentText, MIN_WORDS_LENGTH) ||
+        this.isShortEnough(text, MIN_WORDS_LENGTH) ||
         (/,\s$/.test(currentText) &&
-          ((this.isShortEnough(text, 3) && /,\s$/.test(text)) ||
+          ((this.isShortEnough(text, MIN_WORDS_LENGTH) && /,\s$/.test(text)) ||
             /^\s*and\s/.test(text)))
       ) {
         currentText += text;

--- a/functions/test/TextSplitter.test.ts
+++ b/functions/test/TextSplitter.test.ts
@@ -10,7 +10,8 @@ describe(".run", () => {
 
     assert.sameMembers(TextSplitter.run(testText), [
       "Democrats and recommend Republicans at both the federal",
-      " and state levels are uniting to investigate the power of Big Tech and, potentially, ",
+      " and state levels are uniting",
+      " to investigate the power of Big Tech and, potentially, ",
       "to rein in the dominant companies."
     ]);
   });
@@ -34,7 +35,8 @@ describe(".run", () => {
     assert.sameMembers(TextSplitter.run(testText), [
       "Hackers have been targeting regular people",
       " and celebrities with the attack.Last week, ",
-      "it was used to hijack the Twitter account of Twitter’s C.E.O."
+      "it was used",
+      " to hijack the Twitter account of Twitter’s C.E.O."
     ]);
   });
 
@@ -43,7 +45,8 @@ describe(".run", () => {
       "As Bangladesh vowed to cut off mobile phone access in Rohingya camps, refugees who fled terror in Myanmar despaired over their future.";
 
     assert.sameMembers(TextSplitter.run(testText), [
-      "As Bangladesh vowed to cut off mobile phone access in Rohingya camps, refugees",
+      "As Bangladesh vowed",
+      " to cut off mobile phone access in Rohingya camps, refugees",
       " who fled terror in Myanmar despaired over their future."
     ]);
   });
@@ -81,7 +84,10 @@ describe(".run", () => {
 
   it("文章が適切な位置で分割されること8", () => {
     const testText = "A New TV Show from The New York Times on FX and Hulu";
-    assert.sameMembers(TextSplitter.run(testText), [testText]);
+    assert.sameMembers(TextSplitter.run(testText), [
+      "A New TV Show",
+      " from The New York Times on FX and Hulu"
+    ]);
   });
 });
 


### PR DESCRIPTION
#67
